### PR TITLE
Fix JitPack builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     java
-    kotlin("jvm")
+    maven
+    kotlin("jvm") version "1.3.10"
 }
 
 group = "org.team2471.lib"


### PR DESCRIPTION
Fixes JitPack builds so that meanlib can be imported with maven.

Failing log: https://jitpack.io/com/github/TeamMeanMachine/meanlib/bunnybots2018-310b857ab1-1/build.log
Fixed log: https://jitpack.io/com/github/SouthEugeneRoboticsTeam/meanlib/bunnybots2018-0c9ebadb7e-1/build.log