### PR TITLE
Immediately enable main subsystem

### DIFF
--- a/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
@@ -59,7 +59,7 @@ fun runRobotProgram(robotProgram: RobotProgram): Nothing {
 
     var previousRobotMode: RobotMode? = null
 
-    val mainSubsystem = Subsystem("Robot")
+    val mainSubsystem = Subsystem("Robot").apply { enable() }
 
     while (true) {
         ds.waitForData()


### PR DESCRIPTION
The `startEnabled` argument was removed in 0de30d8eb35ce8099bffb3837076a98bf35d72cc, so the main subsystem was unable to run anything until it got enabled.