### PR TITLE
Allow access to Path2DCurve tailPoint

### DIFF
--- a/src/main/java/org/team2471/frc/lib/motion_profiling/Path2DCurve.java
+++ b/src/main/java/org/team2471/frc/lib/motion_profiling/Path2DCurve.java
@@ -155,6 +155,10 @@ public class Path2DCurve {
         return m_headPoint;
     }
 
+    public Path2DPoint getTailPoint() {
+        return m_tailPoint;
+    }
+
     void fixUpTailAndPrevPointers() {
         Path2DPoint prevPoint = null;
         for (Path2DPoint point = m_headPoint; point != null; point = point.getNextPoint()) {


### PR DESCRIPTION
Makes it easier to update paths on the fly by doing something like:

```kotlin
path.addPointAngleAndMagnitude(0.0, 0.0, 0.0, 1.0)
path.addPointAngleAndMagnitude(1.0, 1.0, 0.0, 1.0)

// path.xyCurve is (0.0, 0.0, 0.0) to (1.0, 1.0, 0.0)

path.removePoint(path.xyCurve.tailPoint)

path.addPointAngleAndMagnitude(2.0, 2.0, 15.0, 1.0)

// path.xyCurve is (0.0, 0.0, 0.0) to (2.0, 2.0, 15.0)