### PR TITLE
Add stopFollowing method to ArcadeRobot

### DIFF
--- a/src/main/java/org/team2471/frc/lib/motion_profiling/following/ArcadeRobot.kt
+++ b/src/main/java/org/team2471/frc/lib/motion_profiling/following/ArcadeRobot.kt
@@ -17,8 +17,8 @@ interface ArcadeRobot {
             rightDistance: Double, rightFeedForward: Double
     )
 
-    fun startFollowing() { //NOOP }
-    fun stopFollowing() { //NOOP }
+    fun startFollowing() { /* NOOP */ }
+    fun stopFollowing() { /* NOOP */ }
 
     fun stop() {
         driveOpenLoop(0.0, 0.0)

--- a/src/main/java/org/team2471/frc/lib/motion_profiling/following/ArcadeRobot.kt
+++ b/src/main/java/org/team2471/frc/lib/motion_profiling/following/ArcadeRobot.kt
@@ -17,7 +17,8 @@ interface ArcadeRobot {
             rightDistance: Double, rightFeedForward: Double
     )
 
-    fun startFollowing()
+    fun startFollowing() { //NOOP }
+    fun stopFollowing() { //NOOP }
 
     fun stop() {
         driveOpenLoop(0.0, 0.0)
@@ -95,6 +96,7 @@ suspend fun <T> T.driveAlongPath(
             }
         } finally {
             stop()
+            stopFollowing()
         }
     }
 


### PR DESCRIPTION
Provides a method that is called when the robot stops following a path. Use case for this is if the robot needs some cleanup to be called after a path is done following that shouldn't be called when using `stop()` to neutralize the drivetrain for reasons outside of path following.