### PR TITLE
Add ability to cancel current subsystem action

### DIFF
--- a/src/main/kotlin/org/team2471/frc/lib/framework/Subsystem.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Subsystem.kt
@@ -58,8 +58,7 @@ open class Subsystem(
      * An optionally overloadable method. This method is automatically run whenever any [use] call completes,
      * regardless of if it completed or canceled.
      */
-    open fun reset() { /* NOOP */
-    }
+    open fun reset() { /* NOOP */ }
 
     /**
      * An optional function that is run whenever the subsystem is enabled and unused.
@@ -74,7 +73,6 @@ open class Subsystem(
             hasDefault = false
         }
     }
-
 
     /**
      * Enables the [Subsystem].
@@ -95,6 +93,12 @@ open class Subsystem(
      */
     fun disable() = EventHandler.disableSubsystem(this)
 
+    /**
+     * Cancels any active coroutine that is currently using the [Subsystem].
+     *
+     * If a [use] call requires more than one [Subsystem], calling [cancelActive] on any of them will have the
+     * same effect.
+     */
     fun cancelActive() = EventHandler.cancelSubsystem(this)
 
     init {

--- a/src/main/kotlin/org/team2471/frc/lib/framework/Subsystem.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Subsystem.kt
@@ -95,6 +95,8 @@ open class Subsystem(
      */
     fun disable() = EventHandler.disableSubsystem(this)
 
+    fun cancelActive() = EventHandler.cancelSubsystem(this)
+
     init {
         enabledEntry.setBoolean(false)
     }

--- a/src/main/kotlin/org/team2471/frc/lib/framework/internal/EventHandler.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/internal/EventHandler.kt
@@ -46,6 +46,10 @@ internal object EventHandler {
         messageChannel.offer(Message.Disable(subsystem))
     }
 
+    fun cancelSubsystem(subsystem: Subsystem) {
+        messageChannel.offer(Message.CancelActiveAction(subsystem))
+    }
+
     private fun resetSubsystem(subsystem: Subsystem) {
         if (subsystem.hasDefault) {
             GlobalScope.launch(MeanlibDispatcher) {
@@ -144,6 +148,8 @@ internal object EventHandler {
                 }
             }
 
+            is Message.CancelActiveAction -> message.subsystem.activeJob?.cancel()
+
             is Message.Clean -> {
                 message.subsystems
                     .filter { it.activeJob === message.job }
@@ -177,6 +183,8 @@ internal object EventHandler {
             val cancelConflicts: Boolean,
             val continuation: CancellableContinuation<Any?>
         ) : Message()
+
+        class CancelActiveAction(val subsystem: Subsystem) : Message()
 
         class Clean(val subsystems: Set<Subsystem>, val job: Job) : Message()
 


### PR DESCRIPTION
This is effectively the same as running an empty `use(Lift) {}` or calling `Lift.disable(); Lift.enable()`. Example use-case would be if a driver would like to abort a previously running action, like climbing or raising a lift.

This seems a lot cleaner (and more intuitive) than running an empty `use(Lift) {}` solely to cancel the actions of that subsystem. Another option would be to continually check in the action for whether it should be aborted (i.e. launch a coroutine checking if a button has been pressed, and cancel the CoroutineScope if was), but I like that even less than an empty action.

There may be a simple solution I'm missing here, but it seems like this could be useful (and has been useful for us).