### PR TITLE
Run enable method if enabled on application start

### DIFF
--- a/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
@@ -81,7 +81,7 @@ fun runRobotProgram(robotProgram: RobotProgram): Nothing {
         // process joystick inputs
         InputMapper.process()
 
-        val wasDisabled = previousRobotMode == RobotMode.DISABLED
+        val wasDisabled = previousRobotMode == RobotMode.DISABLED || previousRobotMode == null
 
         if (previousRobotMode != RobotMode.AUTONOMOUS && ds.isAutonomous) {
             HAL.observeUserProgramAutonomous()


### PR DESCRIPTION
Imagine this robot code:

```kotlin
object Robot : RobotProgram {
    init {
        DriverStationSim().enabled = true
        DriverStationSim().autonomous = false

        periodic { DriverStationSim().notifyNewData() }
    }

    override suspend fun enable() {
        println("Enabling")
    }

    override suspend fun disable() {
        println("Disabling")
    }

    override suspend fun teleop() {
        println("Entering teleop...")
    }

    override suspend fun autonomous() {
        println("Entering autonomous...")
    }
}
```

You'd expect the following to be printed:

```
Enabling
Entering teleop...
```

But the `enable` function is actually skipped because the robot is never registered as disabled (and thus, internally, `wasDisabled == false`). This fixes that issue so that even if the robot is enabled immediately upon starting the program, the `enable` method is still called.

Surprisingly enough, this isn't even just an issue in simulations -- mash the "Enable" button on the Driver Station fast enough while the robot is booting up or after pushing code and the `enable` function sometimes fails to get called!