### PR TITLE
Bump wpilib version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,10 +36,10 @@ dependencies {
     compile("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0")
 
     // frc libs
-    implementation("edu.wpi.first.wpilibj:wpilibj-java:2019.1.1")
-    implementation("edu.wpi.first.hal:hal-java:2019.1.1")
-    implementation("edu.wpi.first.wpiutil:wpiutil-java:2019.1.1")
-    implementation("edu.wpi.first.ntcore:ntcore-java:2019.1.1")
+    implementation("edu.wpi.first.wpilibj:wpilibj-java:2019.3.1")
+    implementation("edu.wpi.first.hal:hal-java:2019.3.1")
+    implementation("edu.wpi.first.wpiutil:wpiutil-java:2019.3.1")
+    implementation("edu.wpi.first.ntcore:ntcore-java:2019.3.1")
     implementation("com.ctre.phoenix:api-java:5.12.0")
 
     // other


### PR DESCRIPTION
Though everything technically works fine as long as the latest version of `GradleRIO` is set in the robot code, inspectors might be looking for `2019.3.1` because it's [technically required](https://www.chiefdelphi.com/t/team-update-14/347799/4?u=andrewda)* to use the latest roboRIO image. To update the version showed in the Driver Station, meanlib's copy of wpilib has to be updated.

![image](https://user-images.githubusercontent.com/10191084/53307678-c6c6cd00-384f-11e9-80f2-295cf7740858.png)

\* Note that `2019.3.2` is the latest GradleRIO version, but `2019.3.1` is the latest wpilib version:

https://github.com/wpilibsuite/GradleRIO/blob/master/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy#L15