### PR TITLE
Constantly process events

### DIFF
--- a/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj.util.WPILibVersion
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.team2471.frc.lib.coroutines.MeanlibDispatcher
+import org.team2471.frc.lib.coroutines.periodic
 import java.io.File
 
 const val LANGUAGE_KOTLIN = 6
@@ -88,9 +89,14 @@ fun runRobotProgram(robotProgram: RobotProgram): Nothing {
 
     val mainSubsystem = Subsystem("Robot").apply { enable() }
 
-    while (true) {
-        Events.process()
+    GlobalScope.launch(MeanlibDispatcher) {
+        periodic {
+            Events.process()
+            if (!ds.isDSAttached) previousRobotMode = null
+        }
+    }
 
+    while (true) {
         ds.waitForData()
 
         if (ds.isDisabled) {

--- a/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
@@ -90,15 +90,13 @@ fun runRobotProgram(robotProgram: RobotProgram): Nothing {
 
     val mainSubsystem = Subsystem("Robot").apply { enable() }
 
-    GlobalScope.launch(MeanlibDispatcher) {
-        periodic {
-            Events.process()
-            if (!ds.isDSAttached) previousRobotMode = RobotMode.DISCONNECTED
-        }
-    }
-
     while (true) {
-        ds.waitForData()
+        val hasNewData = ds.waitForData(0.02)
+
+        Events.process()
+        if (!ds.isDSAttached) previousRobotMode = RobotMode.DISCONNECTED
+
+        if (!hasNewData) continue
 
         if (ds.isDisabled) {
             if (previousRobotMode != RobotMode.DISABLED) {

--- a/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
@@ -47,6 +47,7 @@ interface RobotProgram {
 }
 
 private enum class RobotMode {
+    DISCONNECTED,
     DISABLED,
     AUTONOMOUS,
     TELEOP,
@@ -92,7 +93,7 @@ fun runRobotProgram(robotProgram: RobotProgram): Nothing {
     GlobalScope.launch(MeanlibDispatcher) {
         periodic {
             Events.process()
-            if (!ds.isDSAttached) previousRobotMode = null
+            if (!ds.isDSAttached) previousRobotMode = RobotMode.DISCONNECTED
         }
     }
 


### PR DESCRIPTION
This ensures events are always processed, even when the driver station is disconnected. I'll give this a test in a couple hours and make sure it works as expected.

@tylerscheuble -- I forgot exactly what you had suggested when we chatted at Clackamas, but I believe this should work. If you have any suggestions on how this could be done better, let me know.