### PR TITLE
Add controller unplugged warnings

### DIFF
--- a/src/main/kotlin/org/team2471/frc/lib/input/Controller.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/input/Controller.kt
@@ -1,32 +1,70 @@
 package org.team2471.frc.lib.input
 
 import edu.wpi.first.wpilibj.DriverStation
+import edu.wpi.first.wpilibj.Timer
 import java.lang.IllegalStateException
 
 private val ds = DriverStation.getInstance()
 
 open class Controller(val port: Int) {
-    val isXbox: Boolean
+    private var lastErrorReported = 0.0
+
+    val isXbox
         get() = ds.getJoystickIsXbox(port)
 
-    fun getButton(button: Int) = ds.getStickButton(port, button)
+    val buttonCount
+        get() = ds.getStickButtonCount(port)
+    val axisCount
+        get() = ds.getStickAxisCount(port)
+    val povCount
+        get() = ds.getStickPOVCount(port)
 
-    fun getAxis(axis: Int) = ds.getStickAxis(port, axis)
+    val isConnected
+        get() = buttonCount == 0 && axisCount == 0 && povCount == 0
 
-    fun getPOV(pov: Int = 0) = ds.getStickPOV(port, pov).let { value ->
-        when (value) {
-            -1 -> Direction.IDLE
-            0 -> Direction.UP
-            45 -> Direction.UP_RIGHT
-            90 -> Direction.RIGHT
-            135 -> Direction.DOWN_RIGHT
-            180 -> Direction.DOWN
-            225 -> Direction.DOWN_LEFT
-            270 -> Direction.LEFT
-            315 -> Direction.UP_LEFT
-            else -> throw IllegalStateException("Invalid DPAD value $value")
+    /**
+     * Ensures the [Controller] is connected, and, if not, returns a [backup] value and prints a
+     * warning to the driver station.
+     *
+     * @param backup the backup value to return in case the [Controller] is disconnected
+     * @param body a lambda which returns the value if the [Controller] is connected
+     */
+    private fun <T>ensureConnection(backup: T, body: () -> T) = if (isConnected) {
+        body()
+    } else {
+        val currentTime = Timer.getFPGATimestamp()
+        if (currentTime - lastErrorReported >= JOYSTICK_WARNING_INTERVAL) {
+            lastErrorReported = currentTime
+            DriverStation.reportWarning("Joystick on port $port is disconnected", false)
+        }
+
+        backup
+    }
+
+    fun getButton(button: Int) = ensureConnection(false) { ds.getStickButton(port, button) }
+
+    fun getAxis(axis: Int) = ensureConnection(0.0) { ds.getStickAxis(port, axis) }
+
+    fun getPOV(pov: Int = 0) = ensureConnection(Direction.IDLE) {
+        ds.getStickPOV(port, pov).let { value ->
+            when (value) {
+                -1 -> Direction.IDLE
+                0 -> Direction.UP
+                45 -> Direction.UP_RIGHT
+                90 -> Direction.RIGHT
+                135 -> Direction.DOWN_RIGHT
+                180 -> Direction.DOWN
+                225 -> Direction.DOWN_LEFT
+                270 -> Direction.LEFT
+                315 -> Direction.UP_LEFT
+                else -> throw IllegalStateException("Invalid DPAD value $value")
+            }
         }
     }
 
     enum class Direction { IDLE, UP, UP_RIGHT, RIGHT, DOWN_RIGHT, DOWN, DOWN_LEFT, LEFT, UP_LEFT }
+
+    companion object {
+        private const val JOYSTICK_WARNING_INTERVAL = 2.0
+    }
 }

--- a/src/main/kotlin/org/team2471/frc/lib/input/Controller.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/input/Controller.kt
@@ -20,7 +20,7 @@ open class Controller(val port: Int) {
         get() = ds.getStickPOVCount(port)
 
     val isConnected
-        get() = buttonCount == 0 && axisCount == 0 && povCount == 0
+        get() = buttonCount != 0 || axisCount != 0 || povCount != 0
 
     /**
      * Ensures the [Controller] is connected, and, if not, returns a [backup] value and prints a

--- a/src/main/kotlin/org/team2471/frc/lib/input/Controller.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/input/Controller.kt
@@ -33,7 +33,7 @@ open class Controller(val port: Int) {
         body()
     } else {
         val currentTime = Timer.getFPGATimestamp()
-        if (currentTime - lastErrorReported >= JOYSTICK_WARNING_INTERVAL) {
+        if (ds.isEnabled && currentTime - lastErrorReported >= JOYSTICK_WARNING_INTERVAL) {
             lastErrorReported = currentTime
             DriverStation.reportWarning("Joystick on port $port is disconnected", false)
         }

--- a/src/main/kotlin/org/team2471/frc/lib/input/Controller.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/input/Controller.kt
@@ -7,7 +7,7 @@ import java.lang.IllegalStateException
 private val ds = DriverStation.getInstance()
 
 open class Controller(val port: Int) {
-    private var lastErrorReported = 0.0
+    private var lastWarningReported = 0.0
 
     val isXbox
         get() = ds.getJoystickIsXbox(port)
@@ -33,8 +33,8 @@ open class Controller(val port: Int) {
         body()
     } else {
         val currentTime = Timer.getFPGATimestamp()
-        if (ds.isEnabled && currentTime - lastErrorReported >= JOYSTICK_WARNING_INTERVAL) {
-            lastErrorReported = currentTime
+        if (ds.isEnabled && currentTime - lastWarningReported >= JOYSTICK_WARNING_INTERVAL) {
+            lastWarningReported = currentTime
             DriverStation.reportWarning("Controller on port $port is disconnected", false)
         }
 

--- a/src/main/kotlin/org/team2471/frc/lib/input/Controller.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/input/Controller.kt
@@ -65,6 +65,6 @@ open class Controller(val port: Int) {
     enum class Direction { IDLE, UP, UP_RIGHT, RIGHT, DOWN_RIGHT, DOWN, DOWN_LEFT, LEFT, UP_LEFT }
 
     companion object {
-        private const val JOYSTICK_WARNING_INTERVAL = 2.0
+        private const val JOYSTICK_WARNING_INTERVAL = 5.0
     }
 }

--- a/src/main/kotlin/org/team2471/frc/lib/input/Controller.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/input/Controller.kt
@@ -35,7 +35,7 @@ open class Controller(val port: Int) {
         val currentTime = Timer.getFPGATimestamp()
         if (ds.isEnabled && currentTime - lastErrorReported >= JOYSTICK_WARNING_INTERVAL) {
             lastErrorReported = currentTime
-            DriverStation.reportWarning("Joystick on port $port is disconnected", false)
+            DriverStation.reportWarning("Controller on port $port is disconnected", false)
         }
 
         backup


### PR DESCRIPTION
This will prevent controller unplugged warnings from being printed while the robot is disabled (similar to WPILib) and will print a warning every 5s if the controller is unplugged while the robot is enabled.