### PR TITLE
Add comms method

### DIFF
--- a/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj.util.WPILibVersion
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.team2471.frc.lib.coroutines.MeanlibDispatcher
+import org.team2471.frc.lib.coroutines.periodic
 import java.io.File
 
 const val LANGUAGE_KOTLIN = 6
@@ -54,6 +55,7 @@ interface RobotProgram {
 }
 
 private enum class RobotMode {
+    DISCONNECTED,
     DISABLED,
     AUTONOMOUS,
     TELEOP,
@@ -101,9 +103,10 @@ fun runRobotProgram(robotProgram: RobotProgram): Nothing {
 
         ds.waitForData()
 
-        // TODO: see if the alliance check is really necessary
-        if (previousRobotMode == null && ds.alliance != DriverStation.Alliance.Invalid) {
+        if (previousRobotMode == null || previousRobotMode == RobotMode.DISCONNECTED) {
             robotProgram.comms()
+
+            if (previousRobotMode != null) previousRobotMode = RobotMode.DISABLED
         }
 
         if (ds.isDisabled) {

--- a/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj.util.WPILibVersion
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.team2471.frc.lib.coroutines.MeanlibDispatcher
+import org.team2471.frc.lib.coroutines.periodic
 import java.io.File
 
 const val LANGUAGE_KOTLIN = 6
@@ -88,9 +89,14 @@ fun runRobotProgram(robotProgram: RobotProgram): Nothing {
 
     val mainSubsystem = Subsystem("Robot").apply { enable() }
 
-    while (true) {
-        Events.process()
+    GlobalScope.launch(MeanlibDispatcher) {
+        periodic {
+            Events.process()
+            if (!ds.isDSAttached) previousRobotMode = null
+        }
+    }
 
+    while (true) {
         ds.waitForData()
 
         if (ds.isDisabled) {

--- a/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
@@ -43,6 +43,14 @@ interface RobotProgram {
      * Called immediately after [enable] when the robot's mode transitions to test.
      */
     suspend fun test() { /* NOOP */ }
+
+    /**
+     * Called every time communications are established between the robot and the driver station.
+     * This method can be used to make use of functions that require communication with the driver
+     * station, e.g. [DriverStation.getAlliance] or [DriverStation.getMatchType]. Note that data
+     * from the driver station may not be immediately available and may need to be rechecked.
+     */
+    fun comms() { /* NOOP */ }
 }
 
 private enum class RobotMode {
@@ -92,6 +100,10 @@ fun runRobotProgram(robotProgram: RobotProgram): Nothing {
         Events.process()
 
         ds.waitForData()
+
+        if (previousRobotMode == null && ds.alliance != DriverStation.Alliance.Invalid) {
+            robotProgram.comms()
+        }
 
         if (ds.isDisabled) {
             if (previousRobotMode != RobotMode.DISABLED) {

--- a/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
@@ -90,15 +90,13 @@ fun runRobotProgram(robotProgram: RobotProgram): Nothing {
 
     val mainSubsystem = Subsystem("Robot").apply { enable() }
 
-    GlobalScope.launch(MeanlibDispatcher) {
-        periodic {
-            Events.process()
-            if (!ds.isDSAttached) previousRobotMode = RobotMode.DISCONNECTED
-        }
-    }
-
     while (true) {
-        ds.waitForData()
+        val hasNewData = ds.waitForData(0.02)
+
+        Events.process()
+        if (!ds.isDSAttached) previousRobotMode = RobotMode.DISCONNECTED
+
+        if (!hasNewData) continue
 
         if (ds.isDisabled) {
             if (previousRobotMode != RobotMode.DISABLED) {

--- a/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
@@ -47,6 +47,7 @@ interface RobotProgram {
 }
 
 private enum class RobotMode {
+    DISCONNECTED,
     DISABLED,
     AUTONOMOUS,
     TELEOP,
@@ -92,7 +93,7 @@ fun runRobotProgram(robotProgram: RobotProgram): Nothing {
     GlobalScope.launch(MeanlibDispatcher) {
         periodic {
             Events.process()
-            if (!ds.isDSAttached) previousRobotMode = null
+            if (!ds.isDSAttached) previousRobotMode = RobotMode.DISCONNECTED
         }
     }
 

--- a/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
@@ -101,6 +101,7 @@ fun runRobotProgram(robotProgram: RobotProgram): Nothing {
 
         ds.waitForData()
 
+        // TODO: see if the alliance check is really necessary
         if (previousRobotMode == null && ds.alliance != DriverStation.Alliance.Invalid) {
             robotProgram.comms()
         }


### PR DESCRIPTION
This adds a method that gets called every time communications are established between the robot and the driver station.

An alternative would be:

```kotlin
({ ds.isDSConnected }).whenTrue { robotProgram.comms() }
```

Both work equally well in my testing.