### PR TITLE
Add CoroutineScope.meanlibLaunch method

### DIFF
--- a/src/main/kotlin/org/team2471/frc/lib/coroutines/CoroutineUtils.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/coroutines/CoroutineUtils.kt
@@ -3,6 +3,7 @@ package org.team2471.frc.lib.coroutines
 import edu.wpi.first.wpilibj.DriverStation
 import edu.wpi.first.wpilibj.Watchdog
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -18,6 +19,16 @@ class PeriodicScope @PublishedApi internal constructor(val period: Double) {
         isDone = true
     }
 }
+
+/**
+ * An alias of `launch(MeanlibDispatcher)`.
+ *
+ * @see CoroutineScope.launch
+ */
+fun CoroutineScope.meanlibLaunch(
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    block: suspend CoroutineScope.() -> Unit
+) = launch(MeanlibDispatcher, start, block)
 
 /**
  * Runs the provided [body] of code periodically per [period] seconds.


### PR DESCRIPTION
Considering how much it's used, `meanlibLaunch { }` is nice and short compared to `launch(MeanlibDispatcher) { }` (and also makes it less likely you'll forget the `MeanlibDispatcher`).