### PR TITLE
[WIP] Simplify event loop

### DIFF
--- a/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
+++ b/src/main/kotlin/org/team2471/frc/lib/framework/Base.kt
@@ -48,12 +48,11 @@ abstract class MeanlibRobot : RobotBase() {
             val current = RobotMode.current
             if (previousRobotMode != current) {
                 current.HalObserveUserProgram()
-                val thisRobot = this // why tho
                 val wasDisabled = previousRobotMode == RobotMode.DISABLED
                 GlobalScope.meanlibLaunch {
                     use(mainSubsystem, name = current.name) {
                         if (wasDisabled) enable()
-                        current.action.invoke(thisRobot) // why tho
+                        current.action.invoke(this@MeanlibRobot)
                     }
                 }
                 previousRobotMode = RobotMode.current
@@ -110,8 +109,8 @@ abstract class MeanlibRobot : RobotBase() {
     open fun comms() { /* NOOP */ }
 }
 
-private enum class RobotMode(val action: suspend MeanlibRobot.() -> Unit, val HalObserveUserProgram: KFunction0<Unit>) {
-    DISCONNECTED({ comms() }, {} as KFunction0<Unit>),
+private enum class RobotMode(val action: suspend MeanlibRobot.() -> Unit, val HalObserveUserProgram: () -> Unit) {
+    DISCONNECTED({ comms() }, {}),
     DISABLED(MeanlibRobot::disable, HAL::observeUserProgramDisabled),
     AUTONOMOUS(MeanlibRobot::autonomous, HAL::observeUserProgramAutonomous),
     TELEOP(MeanlibRobot::teleop, HAL::observeUserProgramTeleop),


### PR DESCRIPTION
Varun, from Team 25 here. I've tried to simplify the startCompetition main event loop. 

* Store the associated Hal and robot actions in the RobotMode enum.
* Make the loop only check for a generic state change, and if so execute the associated action. 
* I also need help making line 56 more idiomatic (I need to pass in the current robot object, but "this" now refers to the CoroutineScope.)
* I do not fully understand the ifs at the beginning of the loop (lines 40-46). I'd like to remove this logic and incorporate it into the generic "On robot state change" logic in the rest of the loop.